### PR TITLE
feat: timings routes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod database;
 mod routes;
 
 use rocket_cors::CorsOptions;
-use routes::{trips, users, vehicles, version};
+use routes::{timings, trips, users, vehicles, version};
 
 #[launch]
 fn rocket() -> _ {
@@ -49,4 +49,5 @@ fn rocket() -> _ {
                 trips::delete
             ],
         )
+        .mount("/timings", routes![timings::read])
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5,6 +5,7 @@ pub mod trips;
 pub mod users;
 pub mod vehicles;
 pub mod version;
+pub mod timings;
 
 /// Result for a route using diesel
 type DbResult<T, E = Debug<diesel::result::Error>> = std::result::Result<T, E>;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,11 +1,11 @@
 use rocket::response::Debug;
 
 pub mod auth;
+pub mod timings;
 pub mod trips;
 pub mod users;
 pub mod vehicles;
 pub mod version;
-pub mod timings;
 
 /// Result for a route using diesel
 type DbResult<T, E = Debug<diesel::result::Error>> = std::result::Result<T, E>;

--- a/src/routes/timings.rs
+++ b/src/routes/timings.rs
@@ -1,0 +1,18 @@
+use diesel::prelude::*;
+use provoit_types::models::timings::Timing;
+use rocket::serde::json::Json;
+
+use provoit_types::schema::*;
+
+use super::DbResult;
+use crate::auth::Auth;
+use crate::database::Db;
+
+#[get("/<id>")]
+pub async fn read(db: Db, id: u64, _auth: Auth) -> DbResult<Json<Timing>> {
+    let timing: Timing = db
+        .run(move |conn| timings::table.find(id).get_result(conn))
+        .await?;
+
+    Ok(Json(timing))
+}


### PR DESCRIPTION
I added `timings` related routes. Only `get` on `/<id>` should be useful for this one.