### PR TITLE
Feat/complete trip creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 .vscode
 /target
+
+# Fake data
+fake.sql

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "provoit-types"
 version = "0.1.0"
-source = "git+https://github.com/Provoit/provoit-types.git#d7ac4f60950ccc38512fde5259a254b4c1dcbabf"
+source = "git+https://github.com/Provoit/provoit-types.git#5b1786b2d6e23faeecaf7f6d95ba29b7d7d69110"
 dependencies = [
  "chrono",
  "diesel",


### PR DESCRIPTION
This PR adds the route to create a complete trip. That is, a trip with its start and end timings and road_types.

This is all done in a transaction to guarantee atomicity. Moreover, MySQL doesn't have a `RETURNING` clause to get back the inserted id, so we have to to a second query for that.